### PR TITLE
Add new failures field to shared library.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/BackendCheckUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/BackendCheckUtils.scala
@@ -56,7 +56,7 @@ object BackendCheckUtils {
 
   case class Antivirus(fileId: UUID, software: String, softwareVersion: String, databaseVersion: String, result: String, datetime: Long)
 
-  case class FileCheckResults(antivirus: List[Antivirus], checksum: List[ChecksumResult], fileFormat: List[FFID])
+  case class FileCheckResults(failures: List[String], antivirus: List[Antivirus], checksum: List[ChecksumResult], fileFormat: List[FFID])
 
   case class File(
                    consignmentId: UUID,

--- a/src/test/resources/expected_input.json
+++ b/src/test/resources/expected_input.json
@@ -9,6 +9,9 @@
       "clientChecksum" : "originalFilePath",
       "originalPath" : "checksum",
       "fileCheckResults" : {
+        "failures" : [
+          "FailedLambda"
+        ],
         "antivirus" : [
           {
             "fileId" : "ec5ca215-c9cb-46d6-9c9e-ec8b90fed1db",

--- a/src/test/scala/uk/gov/nationalarchives/BackendCheckUtilsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/BackendCheckUtilsSpec.scala
@@ -31,7 +31,7 @@ class BackendCheckUtilsSpec extends AnyFlatSpec with MockitoSugar with EitherVal
     val checksum = ChecksumResult("checksum", fileId) :: Nil
     val av = Antivirus(fileId, "software", "softwareVersion", "databaseVersion", "result", 1L) :: Nil
     val json = Input(
-      List(File(consignmentId, fileId, userId, "standard", "0", "originalFilePath", "checksum", FileCheckResults(av, checksum, ffid))),
+      List(File(consignmentId, fileId, userId, "standard", "0", "originalFilePath", "checksum", FileCheckResults(List("FailedLambda"), av, checksum, ffid))),
       RedactedResults(RedactedFilePairs(originalFileId, "original", fileId, "redacted") :: Nil, Nil),
       StatusResult(
         List(


### PR DESCRIPTION
These are the case classes which are used to process the state json in
S3. There is a new failures field to show file format lambda failures
which needs to be added.
