### PR TITLE
Don't set defaults for extension mismatches

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/BackendCheckUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/BackendCheckUtils.scala
@@ -50,8 +50,8 @@ object BackendCheckUtils {
 
   case class ChecksumResult(sha256Checksum: String, fileId: UUID)
 
-  case class FFIDMetadataInputMatches(extension: Option[String], identificationBasis: String, puid: Option[String], fileExtensionMismatch: Option[Boolean] = Some(false),
-                                      formatName: Option[String] = Some(""))
+  case class FFIDMetadataInputMatches(extension: Option[String], identificationBasis: String, puid: Option[String], fileExtensionMismatch: Option[Boolean],
+                                      formatName: Option[String])
 
   case class FFID(fileId: java.util.UUID, software: String, softwareVersion: String, binarySignatureFileVersion: String, containerSignatureFileVersion: String, method: String, matches: List[FFIDMetadataInputMatches])
 


### PR DESCRIPTION
Values for the extension mismatch fields should come from DROID only as by setting a default may contradict what DROID reports