### PR TITLE
Persist s3 object location state in results

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/BackendCheckUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/BackendCheckUtils.scala
@@ -67,6 +67,8 @@ object BackendCheckUtils {
                    fileSize: String,
                    clientChecksum: String,
                    originalPath: String,
+                   s3SourceBucket: String,
+                   s3SourceBucketKey: String,
                    fileCheckResults: FileCheckResults
                  )
 

--- a/src/test/resources/expected_input.json
+++ b/src/test/resources/expected_input.json
@@ -8,6 +8,8 @@
       "fileSize" : "0",
       "clientChecksum" : "originalFilePath",
       "originalPath" : "checksum",
+      "s3SourceBucket" : "source-bucket",
+      "s3SourceBucketKey" : "object/key",
       "fileCheckResults" : {
         "antivirus" : [
           {

--- a/src/test/scala/uk/gov/nationalarchives/BackendCheckUtilsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/BackendCheckUtilsSpec.scala
@@ -32,7 +32,7 @@ class BackendCheckUtilsSpec extends AnyFlatSpec with MockitoSugar with EitherVal
     val checksum = ChecksumResult("checksum", fileId) :: Nil
     val av = Antivirus(fileId, "software", "softwareVersion", "databaseVersion", "result", 1L) :: Nil
     val json = Input(
-      List(File(consignmentId, fileId, userId, "standard", "0", "originalFilePath", "checksum", FileCheckResults(av, checksum, ffid))),
+      List(File(consignmentId, fileId, userId, "standard", "0", "originalFilePath", "checksum", "source-bucket", "object/key", FileCheckResults(av, checksum, ffid))),
       RedactedResults(RedactedFilePairs(originalFileId, "original", fileId, "redacted") :: Nil, Nil),
       StatusResult(
         List(


### PR DESCRIPTION
S3 object location state is included as part of the manifest information from the original writing of the manifest from the tdr-file-upload-data lambda

This needs to be persisted to allow the file checks lambda to use for SharePoint transfers as SharePoint records use different bucket keys to transfers coming in via the TDR web application