### PR TITLE
Make s3 fields optional to prevent breaking change

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   private val circeVersion = "0.14.13"
 
-  lazy val awsS3 = "software.amazon.awssdk" % "s3" % "2.26.27"
+  lazy val awsS3 = "software.amazon.awssdk" % "s3" % "2.31.61"
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion

--- a/src/main/scala/uk/gov/nationalarchives/BackendCheckUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/BackendCheckUtils.scala
@@ -67,9 +67,9 @@ object BackendCheckUtils {
                    fileSize: String,
                    clientChecksum: String,
                    originalPath: String,
-                   s3SourceBucket: String,
-                   s3SourceBucketKey: String,
-                   fileCheckResults: FileCheckResults
+                   fileCheckResults: FileCheckResults,
+                   s3SourceBucket: Option[String] = None,
+                   s3SourceBucketKey: Option[String] = None,
                  )
 
   case class RedactedResults(redactedFiles: List[RedactedFilePairs], errors: List[RedactedErrors])

--- a/src/main/scala/uk/gov/nationalarchives/BackendCheckUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/BackendCheckUtils.scala
@@ -67,9 +67,9 @@ object BackendCheckUtils {
                    fileSize: String,
                    clientChecksum: String,
                    originalPath: String,
-                   fileCheckResults: FileCheckResults,
-                   s3SourceBucket: Option[String] = None,
-                   s3SourceBucketKey: Option[String] = None,
+                   s3SourceBucket: Option[String],
+                   s3SourceBucketKey: Option[String],
+                   fileCheckResults: FileCheckResults
                  )
 
   case class RedactedResults(redactedFiles: List[RedactedFilePairs], errors: List[RedactedErrors])

--- a/src/test/resources/expected_input.json
+++ b/src/test/resources/expected_input.json
@@ -8,6 +8,8 @@
       "fileSize" : "0",
       "clientChecksum" : "originalFilePath",
       "originalPath" : "checksum",
+      "s3SourceBucket" : "source-bucket",
+      "s3SourceBucketKey" : "object/key",
       "fileCheckResults" : {
         "antivirus" : [
           {
@@ -44,9 +46,7 @@
             ]
           }
         ]
-      },
-      "s3SourceBucket" : "source-bucket",
-      "s3SourceBucketKey" : "object/key"
+      }
     }
   ],
   "redactedResults" : {

--- a/src/test/resources/no_optional_fields_expected_input.json
+++ b/src/test/resources/no_optional_fields_expected_input.json
@@ -35,18 +35,18 @@
             "method" : "method",
             "matches" : [
               {
-                "extension" : "txt",
+                "extension" : null,
                 "identificationBasis" : "Some basis",
-                "puid" : "x-fmt/111",
-                "fileExtensionMismatch" : true,
-                "formatName" : "format-name"
+                "puid" : null,
+                "fileExtensionMismatch" : null,
+                "formatName" : null
               }
             ]
           }
         ]
       },
-      "s3SourceBucket" : "source-bucket",
-      "s3SourceBucketKey" : "object/key"
+      "s3SourceBucket" : null,
+      "s3SourceBucketKey" : null
     }
   ],
   "redactedResults" : {

--- a/src/test/resources/no_optional_fields_expected_input.json
+++ b/src/test/resources/no_optional_fields_expected_input.json
@@ -35,18 +35,12 @@
             "method" : "method",
             "matches" : [
               {
-                "extension" : null,
-                "identificationBasis" : "Some basis",
-                "puid" : null,
-                "fileExtensionMismatch" : null,
-                "formatName" : null
+                "identificationBasis" : "Some basis"
               }
             ]
           }
         ]
-      },
-      "s3SourceBucket" : null,
-      "s3SourceBucketKey" : null
+      }
     }
   ],
   "redactedResults" : {

--- a/src/test/scala/uk/gov/nationalarchives/BackendCheckUtilsSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/BackendCheckUtilsSpec.scala
@@ -32,7 +32,7 @@ class BackendCheckUtilsSpec extends AnyFlatSpec with MockitoSugar with EitherVal
     val checksum = ChecksumResult("checksum", fileId) :: Nil
     val av = Antivirus(fileId, "software", "softwareVersion", "databaseVersion", "result", 1L) :: Nil
     val json = Input(
-      List(File(consignmentId, fileId, userId, "standard", "0", "originalFilePath", "checksum", "source-bucket", "object/key", FileCheckResults(av, checksum, ffid))),
+      List(File(consignmentId, fileId, userId, "standard", "0", "originalFilePath", "checksum", FileCheckResults(av, checksum, ffid), Some("source-bucket"), Some("object/key"))),
       RedactedResults(RedactedFilePairs(originalFileId, "original", fileId, "redacted") :: Nil, Nil),
       StatusResult(
         List(
@@ -42,6 +42,29 @@ class BackendCheckUtilsSpec extends AnyFlatSpec with MockitoSugar with EitherVal
       )
     ).asJson.printWith(spaces2)
     val expectedJson = Source.fromResource("expected_input.json").mkString
+    json.trim should equal(expectedJson.trim)
+  }
+
+  "the case classes" should "handle optional fields" in {
+    val consignmentId = UUID.fromString("2f1261c5-d5e7-4865-8078-c0bc6333164f")
+    val fileId = UUID.fromString("ec5ca215-c9cb-46d6-9c9e-ec8b90fed1db")
+    val userId = UUID.fromString("18c24625-e336-4dca-bda8-9bea30eb213b")
+    val originalFileId = UUID.fromString("db75e4e5-ee0a-4269-88d2-c1de8c73020d")
+    val ffidMatches = FFIDMetadataInputMatches(None, "Some basis", None, None, None)
+    val ffid = FFID(fileId, "software", "softwareVersion", "binarySignatureFileVersion", "containerSignatureFileVersion", "method",  ffidMatches :: Nil) :: Nil
+    val checksum = ChecksumResult("checksum", fileId) :: Nil
+    val av = Antivirus(fileId, "software", "softwareVersion", "databaseVersion", "result", 1L) :: Nil
+    val json = Input(
+      List(File(consignmentId, fileId, userId, "standard", "0", "originalFilePath", "checksum", FileCheckResults(av, checksum, ffid))),
+      RedactedResults(RedactedFilePairs(originalFileId, "original", fileId, "redacted") :: Nil, Nil),
+      StatusResult(
+        List(
+          Status(UUID.fromString("27506737-37fa-4899-b494-4871f7bc3141"), "Consignment", "Status", "StatusValue"),
+          Status(UUID.fromString("847e1b70-f3d6-4f4d-8f60-1f307a7df126"), "Consignment", "OverwriteStatus", "OverwriteStatusValue", overwrite = true)
+        )
+      )
+    ).asJson.printWith(spaces2)
+    val expectedJson = Source.fromResource("no_optional_fields_expected_input.json").mkString
     json.trim should equal(expectedJson.trim)
   }
 


### PR DESCRIPTION
The result json generated by the backend checks goes through multiple re-writes by different lambdas

As a result the s3 source information is missing when this lambda is call at the end of the process, causing a de-coding failure as not all the previous lambdas are persisting the s3 source location information when they re-write the results json

Once all the backend checks lambdas are upgrade to latest version of this library this issue will no longer be present,